### PR TITLE
Added support for minLength=0, added all value for items and showHintOnFocus option

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -39,7 +39,8 @@
     this.source = this.options.source
     this.$menu = $(this.options.menu)
     this.shown = false
-    this.listen()
+    this.listen(),
+    this.showHintOnFocus = typeof this.options.showHintOnFocus == 'boolean' ? this.options.showHintOnFocus : false
   }
 
   Typeahead.prototype = {
@@ -90,9 +91,9 @@
   , lookup: function (event) {
       var items
 
-      this.query = this.$element.val()
+      this.query = this.$element.val()  || ''
 
-      if (!this.query || this.query.length < this.options.minLength) {
+      if (this.query.length < this.options.minLength) {
         return this.shown ? this.hide() : this
       }
 
@@ -114,7 +115,11 @@
         return this.shown ? this.hide() : this
       }
 
-      return this.render(items.slice(0, this.options.items)).show()
+      if (this.options.items == 'all' || this.options.minLength == 0 && !this.$element.val()) {
+        return this.render(items).show()
+      } else {	
+        return this.render(items.slice(0, this.options.items)).show()
+      }
     }
 
   , matcher: function (item) {
@@ -271,6 +276,9 @@
 
   , focus: function (e) {
       this.focused = true
+      if (this.options.minLength == 0 && !this.$element.val() || this.options.matchOnFocus) {
+        this.lookup(); 
+      }
     }
 
   , blur: function (e) {


### PR DESCRIPTION
Added support for a minLength of 0 that displays the hints on focus and when user clears the field. The showHintsOnFocus can be set to true so hints are shown whenever user enters the field (even if minLength is grater than 0). You can also set the count of items to 'all' if you do not want to limit the number of items shown. This is always the case when minLength == 0 and no value is enter (all the hints are shown).

I suggest user add some styling to typeahead when using 'all' items or minLength=0 to limit the size of the pop-up: 
.typeahead{
    max-height:150px;
    overflow-y:auto
}
