### PR TITLE
Code cleanup to make it jshint-compliant 

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -22,44 +22,45 @@
 
 !function($){
 
-  "use strict"; // jshint ;_;
+  "use strict";
+  // jshint laxcomma: true
 
 
  /* TYPEAHEAD PUBLIC CLASS DEFINITION
   * ================================= */
 
   var Typeahead = function (element, options) {
-    this.$element = $(element)
-    this.options = $.extend({}, $.fn.typeahead.defaults, options)
-    this.matcher = this.options.matcher || this.matcher
-    this.sorter = this.options.sorter || this.sorter
-    this.select = this.options.select || this.select
-    this.autoSelect = typeof this.options.autoSelect == 'boolean' ? this.options.autoSelect : true
-    this.highlighter = this.options.highlighter || this.highlighter
-    this.updater = this.options.updater || this.updater
-    this.source = this.options.source
-    this.$menu = $(this.options.menu)
-    this.shown = false
-    this.listen(),
-	this.showHintOnFocus = typeof this.options.showHintOnFocus == 'boolean' ? this.options.showHintOnFocus : false
-  }
+    this.$element = $(element);
+    this.options = $.extend({}, $.fn.typeahead.defaults, options);
+    this.matcher = this.options.matcher || this.matcher;
+    this.sorter = this.options.sorter || this.sorter;
+    this.select = this.options.select || this.select;
+    this.autoSelect = typeof this.options.autoSelect == 'boolean' ? this.options.autoSelect : true;
+    this.highlighter = this.options.highlighter || this.highlighter;
+    this.updater = this.options.updater || this.updater;
+    this.source = this.options.source;
+    this.$menu = $(this.options.menu);
+    this.shown = false;
+    this.listen();
+    this.showHintOnFocus = typeof this.options.showHintOnFocus == 'boolean' ? this.options.showHintOnFocus : false;
+  };
 
   Typeahead.prototype = {
 
     constructor: Typeahead
-	
+
   , select: function () {
-      var val = this.$menu.find('.active').attr('data-value')
+      var val = this.$menu.find('.active').attr('data-value');
       if(this.autoSelect || val) {
         this.$element
           .val(this.updater(val))
-          .change()
+          .change();
       }
-      return this.hide()
+      return this.hide();
     }
 
   , updater: function (item) {
-      return item
+      return item;
     }
 
   , setSource: function (source) {
@@ -69,11 +70,11 @@
   , show: function () {
       var pos = $.extend({}, this.$element.position(), {
         height: this.$element[0].offsetHeight
-      }), scrollHeight
+      }), scrollHeight;
       
       scrollHeight = typeof this.options.scrollHeight == 'function' ?
           this.options.scrollHeight.call() :
-          this.options.scrollHeight
+          this.options.scrollHeight;
 
       this.$menu
         .insertAfter(this.$element)
@@ -81,117 +82,117 @@
           top: pos.top + pos.height + scrollHeight
         , left: pos.left
         })
-        .show()
+        .show();
 
-      this.shown = true
-      return this
+      this.shown = true;
+      return this;
     }
 
   , hide: function () {
-      this.$menu.hide()
-      this.shown = false
-      return this
+      this.$menu.hide();
+      this.shown = false;
+      return this;
     }
 
   , lookup: function (query) {
-      var items      
-	  if (typeof(query) != 'undefined' && query != null) {
-		this.query = query;
-	  } else {
-		this.query = this.$element.val() ||  '';
-	  }
-
-      if (this.query.length < this.options.minLength) {
-        return this.shown ? this.hide() : this
+      var items;
+      if (typeof(query) != 'undefined' && query !== null) {
+        this.query = query;
+      } else {
+        this.query = this.$element.val() ||  '';
       }
 
-      items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source
+      if (this.query.length < this.options.minLength) {
+        return this.shown ? this.hide() : this;
+      }
 
-      return items ? this.process(items) : this
+      items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source;
+
+      return items ? this.process(items) : this;
     }
 
   , process: function (items) {
-      var that = this
+      var that = this;
 
       items = $.grep(items, function (item) {
-        return that.matcher(item)
-      })
+        return that.matcher(item);
+      });
 
-      items = this.sorter(items)
+      items = this.sorter(items);
 
       if (!items.length) {
-        return this.shown ? this.hide() : this
+        return this.shown ? this.hide() : this;
       }
-	  
-	  if (this.options.items == 'all' || this.options.minLength == 0 && !this.$element.val()) {
-		return this.render(items).show()
-	  } else {	
-		return this.render(items.slice(0, this.options.items)).show()
-	  }
+
+      if (this.options.items == 'all' || this.options.minLength === 0 && !this.$element.val()) {
+        return this.render(items).show();
+      } else {
+        return this.render(items.slice(0, this.options.items)).show();
+      }
     }
 
   , matcher: function (item) {
-      return ~item.toLowerCase().indexOf(this.query.toLowerCase())
+      return ~item.toLowerCase().indexOf(this.query.toLowerCase());
     }
 
   , sorter: function (items) {
       var beginswith = []
         , caseSensitive = []
         , caseInsensitive = []
-        , item
+        , item;
 
-      while (item = items.shift()) {
-        if (!item.toLowerCase().indexOf(this.query.toLowerCase())) beginswith.push(item)
-        else if (~item.indexOf(this.query)) caseSensitive.push(item)
-        else caseInsensitive.push(item)
+      while ((item = items.shift())) {
+        if (!item.toLowerCase().indexOf(this.query.toLowerCase())) beginswith.push(item);
+        else if (~item.indexOf(this.query)) caseSensitive.push(item);
+        else caseInsensitive.push(item);
       }
 
-      return beginswith.concat(caseSensitive, caseInsensitive)
+      return beginswith.concat(caseSensitive, caseInsensitive);
     }
 
   , highlighter: function (item) {
-      var query = this.query.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&')
+      var query = this.query.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&');
       return item.replace(new RegExp('(' + query + ')', 'ig'), function ($1, match) {
-        return '<strong>' + match + '</strong>'
-      })
+        return '<strong>' + match + '</strong>';
+      });
     }
 
   , render: function (items) {
-      var that = this
+      var that = this;
 
       items = $(items).map(function (i, item) {
-        i = $(that.options.item).attr('data-value', item)
-        i.find('a').html(that.highlighter(item))
-        return i[0]
-      })
+        i = $(that.options.item).attr('data-value', item);
+        i.find('a').html(that.highlighter(item));
+        return i[0];
+      });
 
       if (this.autoSelect) {
-        items.first().addClass('active')
+        items.first().addClass('active');
       }
-      this.$menu.html(items)
-      return this
+      this.$menu.html(items);
+      return this;
     }
 
   , next: function (event) {
       var active = this.$menu.find('.active').removeClass('active')
-        , next = active.next()
+        , next = active.next();
 
       if (!next.length) {
-        next = $(this.$menu.find('li')[0])
+        next = $(this.$menu.find('li')[0]);
       }
 
-      next.addClass('active')
+      next.addClass('active');
     }
 
   , prev: function (event) {
       var active = this.$menu.find('.active').removeClass('active')
-        , prev = active.prev()
+        , prev = active.prev();
 
       if (!prev.length) {
-        prev = this.$menu.find('li').last()
+        prev = this.$menu.find('li').last();
       }
 
-      prev.addClass('active')
+      prev.addClass('active');
     }
 
   , listen: function () {
@@ -199,161 +200,161 @@
         .on('focus',    $.proxy(this.focus, this))
         .on('blur',     $.proxy(this.blur, this))
         .on('keypress', $.proxy(this.keypress, this))
-        .on('keyup',    $.proxy(this.keyup, this))
+        .on('keyup',    $.proxy(this.keyup, this));
 
       if (this.eventSupported('keydown')) {
-        this.$element.on('keydown', $.proxy(this.keydown, this))
+        this.$element.on('keydown', $.proxy(this.keydown, this));
       }
 
       this.$menu
         .on('click', $.proxy(this.click, this))
         .on('mouseenter', 'li', $.proxy(this.mouseenter, this))
-        .on('mouseleave', 'li', $.proxy(this.mouseleave, this))
-	}
+        .on('mouseleave', 'li', $.proxy(this.mouseleave, this));
+    }
   , destroy : function () {
-		   this.$element.data('typeahead',null)
-			this.$element
-			.off('focus')
-			.off('blur')
-			.off('keypress')
-			.off('keyup')
+      this.$element.data('typeahead',null);
+      this.$element
+        .off('focus')
+        .off('blur')
+        .off('keypress')
+        .off('keyup');
 
-		  if (this.eventSupported('keydown')) {
-			this.$element.off('keydown')
-		  }
-
-		  this.$menu.remove();
-	}	
-  , eventSupported: function(eventName) {
-      var isSupported = eventName in this.$element
-      if (!isSupported) {
-        this.$element.setAttribute(eventName, 'return;')
-        isSupported = typeof this.$element[eventName] === 'function'
+      if (this.eventSupported('keydown')) {
+        this.$element.off('keydown');
       }
-      return isSupported
+
+      this.$menu.remove();
+    }
+  , eventSupported: function(eventName) {
+      var isSupported = eventName in this.$element;
+      if (!isSupported) {
+        this.$element.setAttribute(eventName, 'return;');
+        isSupported = typeof this.$element[eventName] === 'function';
+      }
+      return isSupported;
     }
 
   , move: function (e) {
-      if (!this.shown) return
+      if (!this.shown) return;
 
       switch(e.keyCode) {
         case 9: // tab
         case 13: // enter
         case 27: // escape
-          e.preventDefault()
-          break
+          e.preventDefault();
+          break;
 
         case 38: // up arrow
-          e.preventDefault()
-          this.prev()
-          break
+          e.preventDefault();
+          this.prev();
+          break;
 
         case 40: // down arrow
-          e.preventDefault()
-          this.next()
-          break
+          e.preventDefault();
+          this.next();
+          break;
       }
 
-      e.stopPropagation()
+      e.stopPropagation();
     }
 
   , keydown: function (e) {
       this.suppressKeyPressRepeat = ~$.inArray(e.keyCode, [40,38,9,13,27]);
-	  if (!this.shown && e.keyCode == 40) {
-		this.lookup("");
-	  } else {
-		this.move(e)
-	  }
+      if (!this.shown && e.keyCode == 40) {
+        this.lookup("");
+      } else {
+        this.move(e);
+      }
     }
 
   , keypress: function (e) {
-      if (this.suppressKeyPressRepeat) return
-      this.move(e)
+      if (this.suppressKeyPressRepeat) return;
+      this.move(e);
     }
 
   , keyup: function (e) {
-      switch(e.keyCode) {  
-		case 40: // down arrow      
+      switch(e.keyCode) {
+        case 40: // down arrow
         case 38: // up arrow
         case 16: // shift
         case 17: // ctrl
         case 18: // alt
-          break
+          break;
 
         case 9: // tab
         case 13: // enter
-          if (!this.shown) return
-          this.select()
-          break
+          if (!this.shown) return;
+          this.select();
+          break;
 
         case 27: // escape
-          if (!this.shown) return
-          this.hide()
-          break		
+          if (!this.shown) return;
+          this.hide();
+          break;
         default:
-          this.lookup()
+          this.lookup();
       }
 
-      e.stopPropagation()
-      e.preventDefault()
+      e.stopPropagation();
+      e.preventDefault();
   }
 
   , focus: function (e) {
-	  if (!this.focused) {
-		  this.focused = true
-		  if (this.options.minLength == 0 && !this.$element.val() || this.options.showHintOnFocus) {
-			this.lookup(); 
-		  }
-	  }
+      if (!this.focused) {
+        this.focused = true;
+        if (this.options.minLength === 0 && !this.$element.val() || this.options.showHintOnFocus) {
+          this.lookup(); 
+        }
+      }
     }
 
   , blur: function (e) {
-      this.focused = false
-      if (!this.mousedover && this.shown) this.hide()
+      this.focused = false;
+      if (!this.mousedover && this.shown) this.hide();
     }
 
   , click: function (e) {
-      e.stopPropagation()
-      e.preventDefault()
-      this.select()
-      this.$element.focus()
+      e.stopPropagation();
+      e.preventDefault();
+      this.select();
+      this.$element.focus();
     }
 
   , mouseenter: function (e) {
-      this.mousedover = true
-      this.$menu.find('.active').removeClass('active')
-      $(e.currentTarget).addClass('active')
+      this.mousedover = true;
+      this.$menu.find('.active').removeClass('active');
+      $(e.currentTarget).addClass('active');
     }
 
   , mouseleave: function (e) {
-      this.mousedover = false
-      if (!this.focused && this.shown) this.hide()
+      this.mousedover = false;
+      if (!this.focused && this.shown) this.hide();
     }
 
-  }
+  };
 
 
   /* TYPEAHEAD PLUGIN DEFINITION
    * =========================== */
 
-  var old = $.fn.typeahead
+  var old = $.fn.typeahead;
 
   $.fn.typeahead = function (option) {
 	var arg = arguments;
     return this.each(function () {
       var $this = $(this)
         , data = $this.data('typeahead')
-        , options = typeof option == 'object' && option
-      if (!data) $this.data('typeahead', (data = new Typeahead(this, options)))
+        , options = typeof option == 'object' && option;
+      if (!data) $this.data('typeahead', (data = new Typeahead(this, options)));
       if (typeof option == 'string') {
-		if (arg.length > 1) {
-			data[option].apply(data, Array.prototype.slice.call(arg ,1));
-		} else {
-			data[option]()
-		}
-	  }
-    })
-  }
+        if (arg.length > 1) {
+          data[option].apply(data, Array.prototype.slice.call(arg ,1));
+        } else {
+          data[option]();
+        }
+      }
+    });
+  };
 
   $.fn.typeahead.defaults = {
     source: []
@@ -363,27 +364,27 @@
   , minLength: 1
   , scrollHeight: 0
   , autoSelect: true
-  }
+  };
 
-  $.fn.typeahead.Constructor = Typeahead
+  $.fn.typeahead.Constructor = Typeahead;
 
 
  /* TYPEAHEAD NO CONFLICT
   * =================== */
 
   $.fn.typeahead.noConflict = function () {
-    $.fn.typeahead = old
-    return this
-  }
+    $.fn.typeahead = old;
+    return this;
+  };
 
 
  /* TYPEAHEAD DATA-API
   * ================== */
 
   $(document).on('focus.typeahead.data-api', '[data-provide="typeahead"]', function (e) {
-    var $this = $(this)
-    if ($this.data('typeahead')) return
-    $this.typeahead($this.data())
-  })
+    var $this = $(this);
+    if ($this.data('typeahead')) return;
+    $this.typeahead($this.data());
+  });
 
 }(window.jQuery);


### PR DESCRIPTION
I added a bunch of semicolons and fixed the mixed tabs/spaces.
I also added the jshint [`laxcomma`](http://www.jshint.com/docs/options/#laxcomma) option for suppressing warnings about comma-first coding style.

Running `jshint` now only throws one error

```
> jshint bootstrap3-typeahead.js
bootstrap3-typeahead.js: line 390, col 16, Expected an assignment or function call and instead saw an expression.

1 error
```

because of the `!function(){ /* … */ }()` pattern.
