### PR TITLE
Fix bug regarding the number of items shown in the dropdown menu

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -124,7 +124,7 @@
         return this.shown ? this.hide() : this;
       }
 
-      if (this.options.items == 'all' || this.options.minLength === 0 && !this.$element.val()) {
+      if (this.options.items == 'all') {
         return this.render(items).show();
       } else {
         return this.render(items.slice(0, this.options.items)).show();


### PR DESCRIPTION
When the input is empty, minLength=0 and showHintOnFocus=true, only 'items' elements are shown in the dropdown menu.

As it was before, even after specifying for example a maximum of 10 items, all of them were shown in the scenario described above.
