### PR TITLE
Add the option 'delay' in order to reduce the number of request to the server while typing

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -39,6 +39,7 @@
     this.highlighter = this.options.highlighter || this.highlighter;
     this.updater = this.options.updater || this.updater;
     this.source = this.options.source;
+    this.delay = typeof this.options.delay == 'number' ? this.options.delay : 250;
     this.$menu = $(this.options.menu);
     this.shown = false;
     this.listen();
@@ -106,9 +107,15 @@
         return this.shown ? this.hide() : this;
       }
 
-      items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source;
+      var worker = $.proxy(function() {
+        items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source;
+        if (items) {
+          this.process(items);
+        }
+      }, this)
 
-      return items ? this.process(items) : this;
+      clearTimeout(this.lookupWorker)
+      this.lookupWorker = setTimeout(worker, this.delay)
     }
 
   , process: function (items) {


### PR DESCRIPTION
I added a numeric option called 'delay' (with a default value of 250ms), so that when you're typing, let's say "foo bar", only one single request is sent to the server (assuming you type fast enough :)), not 7 as it was working until now. It is disbled with the value "0" (actually with any non-positive value).

Just in case, I read all the calls to _lookup_ and the returned value was not being used anywhere. The documentation says ".lookup: To trigger the lookup function externally", it doesn't say it returns anything useful so I guess it's ok...
