### PR TITLE
add after select callback feature

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -62,6 +62,7 @@
     this.shown = false;
     this.listen();
     this.showHintOnFocus = typeof this.options.showHintOnFocus == 'boolean' ? this.options.showHintOnFocus : false;
+    this.afterSelect = this.options.afterSelect
   };
 
   Typeahead.prototype = {
@@ -74,6 +75,7 @@
         this.$element
           .val(this.updater(val))
           .change();
+        this.afterSelect();
       }
       return this.hide();
     }
@@ -409,6 +411,7 @@
   , minLength: 1
   , scrollHeight: 0
   , autoSelect: true
+  , afterSelect: $.noop
   };
 
   $.fn.typeahead.Constructor = Typeahead;


### PR DESCRIPTION
I first try using on change events on the input field for a after select callback but it seems to have 2 change events triggered from the default dom input change event and in this typeahead plugin code. So I made a after select callback for it.

Just ignore commit 'fixed window scope for chrome extensions' its just for my own use.
