### PR TITLE
Case insensitive highlighter

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -180,7 +180,7 @@
   , highlighter: function (item) {
           var html = $('<div></div>');
           var query = this.query;
-          var i = item.indexOf(query);
+          var i = item.toLowerCase().indexOf(query);
           var len, leftPart, middlePart, rightPart, strong;
           len = query.length;
           if(len == 0){


### PR DESCRIPTION
For example, data = ['Bootstrap', 'Typeahead'].
If users type 'bootstrap' or 'typeahead', corresponding characters
should be highlighted.
