### PR TITLE
Case insensitive highlighter

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -180,7 +180,7 @@
   , highlighter: function (item) {
           var html = $('<div></div>');
           var query = this.query;
-          var i = item.indexOf(query);
+          var i = item.toLowerCase().indexOf(query.toLowerCase());
           var len, leftPart, middlePart, rightPart, strong;
           len = query.length;
           if(len == 0){


### PR DESCRIPTION
For example, data = ['Bootstrap', 'typeahead'].
If users type 'boo' or 'Typ', corresponding characters should be highlighted.

Left: New, Right: Current
![caseinsensitivehighlighter](https://cloud.githubusercontent.com/assets/4402060/4956825/29a3ed72-669f-11e4-95b9-92f4c7b886f9.png)

Mine
http://jsfiddle.net/nrh9dxxo/

Current
http://jsfiddle.net/udk4d4nh/
