### PR TITLE
Added support for json object in the source

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Loading a collection
 Using JSON objects instead of simple strings
 --------------------------------------------
 
-You can add all the properties you wish on your objects, as long as you provide a "name" attribute OR you provide your own getDisplayText method. The other values are for you, to be able to match the selected item with something in your model.
+You can add all the properties you wish on your objects, as long as you provide a "name" attribute OR you provide your own displayText method. The other values are for you, to be able to match the selected item with something in your model.
 	
 	var $input = $('.typeahead');
 	$input.typeahead({source:[{id: "someId1", name: "Display name 1"}, 
@@ -156,10 +156,10 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
                  <td>Method used to highlight autocomplete results. Accepts a single argument <code>item</code> and has the scope of the typeahead instance. Should return html.</td>
                </tr>
 			   <tr>
-                 <td>getDisplayText</td>
+                 <td>displayText</td>
                  <td>function</td>
-                 <td>gets the display text of an item</td>
-                 <td>Method used to get textual representation of an item of the sources. Accepts a single argument <code>item</code> and has the scope of the typeahead instance. Should return a String, returns item or item.name by default.</td>
+                 <td>item.name || item</td>
+                 <td>Method used to get textual representation of an item of the sources. Accepts a single argument <code>item</code> and has the scope of the typeahead instance. Should return a String.</td>
                </tr>
               <tr>
                  <td>autoSelect</td>

--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -56,7 +56,7 @@
     this.highlighter = this.options.highlighter || this.highlighter;
     this.render = this.options.render || this.render;
     this.updater = this.options.updater || this.updater;
-	this.getDisplayText = this.options.getDisplayText || this.getDisplayText;
+	this.displayText = this.options.displayText || this.displayText;
     this.source = this.options.source;
     this.delay = this.options.delay;
     this.$menu = $(this.options.menu);
@@ -168,7 +168,7 @@
     }
 
   , matcher: function (item) {
-    var it = this.getDisplayText(item);
+    var it = this.displayText(item);
       return ~it.toLowerCase().indexOf(this.query.toLowerCase());
     }
 
@@ -179,7 +179,7 @@
         , item;
 
       while ((item = items.shift())) {
-        var it = this.getDisplayText(item);
+        var it = this.displayText(item);
         if (!it.toLowerCase().indexOf(this.query.toLowerCase())) beginswith.push(item);
         else if (~it.indexOf(this.query)) caseSensitive.push(item);
         else caseInsensitive.push(item);
@@ -216,7 +216,7 @@
       var self = this;
       var activeFound = false;
       items = $(items).map(function (i, item) {
-        var text = self.getDisplayText(item);
+        var text = self.displayText(item);
         i = $(that.options.item).data('value', item);
         i.find('a').html(that.highlighter(text));
         if (text == self.$element.val()) {
@@ -235,7 +235,7 @@
       return this;
     }
 
-  , getDisplayText: function(item) {
+  , displayText: function(item) {
       return item.name || item;
   }
 


### PR DESCRIPTION
With this pull request, you can now pass elements like {id: "myId" name: "Display Name"} in the source and retrieved the active item to know if one of your element was chosen by the user. Useful when display value and save values differs. Any properties can be put on the json object as long as it has a name.
