### PR TITLE
fix commonjs module loader

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -26,7 +26,7 @@
 
   // CommonJS module is defined
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports = factory(require('jquery')(root));
+    module.exports = factory(require('jquery'));
   }
   // AMD module is defined
   else if (typeof define === "function" && define.amd) {


### PR DESCRIPTION
require('jquery')(root) provides root object to the plugin instead of jQuery if you load it with browserify.
Removing (root) solves the problem.
