### PR TITLE
Update bootstrap3-typeahead.js

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -133,7 +133,7 @@
 
       var worker = $.proxy(function() {
 
-        if($.isFunction(this.source)) this.source(this.query, $.proxy(this.process, this));
+        if($.isFunction(this.source)) this.process(this.source(this.query, $.proxy(this.process, this)));
         else if (this.source) {
           this.process(this.source);
         }


### PR DESCRIPTION
Typeahead is not working with sourece as function.