### PR TITLE
Fix for displayText undefined values

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -243,7 +243,7 @@
     },
 
     displayText: function(item) {
-      return item.name || item;
+      return typeof item !== 'undefined' && typeof item.name != 'undefined' && item.name || item;
     },
 
     next: function (event) {


### PR DESCRIPTION
Prevent errors in displayText function if the item or item.name is undefined.