### PR TITLE
Add null check for newVal to avoid exception.

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -77,6 +77,11 @@
       this.$element.data('active', val);
       if(this.autoSelect || val) {
         var newVal = this.updater(val);
+        // Updater can be set to any random functions via "options" parameter in constructor above.
+        // Add null check for cases when upadter returns void or undefined.
+        if (!newVal) {
+          newVal = "";	
+        }
         this.$element
           .val(this.displayText(newVal) || newVal)
           .change();


### PR DESCRIPTION
newVal is set to undefined when I am trying to use tpyeahead in Bootstrap-tagsinput:
https://github.com/timschlechter/bootstrap-tagsinput
This will cause exception in this.displayText(newVal): can not access 'name' of undefined.