### PR TITLE
Code for data-attributes to work with callback functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
                  <td>afterSelect</td>
                  <td>function</td>
                  <td>$.noop()</td>
-                 <td>Call back function to execute after selected an item. It gets the current active item in parameter if any.</td>
+                 <td>Call back function to execute after selected an item. It gets the current active item in parameter if any. Data attribute is data-after-select.</td>
                </tr>
 			   <tr>
                  <td>delay</td>

--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -76,7 +76,11 @@
       var val = this.$menu.find('.active').data('value');
       this.$element.data('active', val);
       if(this.autoSelect || val) {
-        var newVal = this.updater(val);
+	  if(typeof this.updater == "function"){
+	      var newVal = this.updater(val);
+	  }else{
+	      var newVal = window[this.updater](val);
+	  }
         // Updater can be set to any random functions via "options" parameter in constructor above.
         // Add null check for cases when upadter returns void or undefined.
         if (!newVal) {
@@ -85,7 +89,11 @@
         this.$element
           .val(this.displayText(newVal) || newVal)
           .change();
+	if(typeof this.afterSelect == "function"){
         this.afterSelect(newVal);
+	}else{
+	    window[this.afterSelect](newVal);
+	}
       }
       return this.hide();
     },


### PR DESCRIPTION
Basically if I have code like this

```
<script>
foo=function(item){ console.log(item); }
</script>
<input type="text" data-provide="typeahead" data-source='["hi","bye"]' data-after-select="searchSubmit"/>
```
I will get the error this.afterSelect is not a function because it does not try to call the function name stored in data-after-select.
What this patch does is it will check if afterSelect is a string and if so call the stored function name.