### PR TITLE
Fix bower setup instructions. Use git url instead of ssh.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ To use with [Bower](http://bower.io/). Add to your bower.json file:
 	{
             "name": "MyProject",
             "dependencies": {
-            "bootstrap3-typeahead": "git@github.com:bassjobsen/Bootstrap-3-Typeahead.git#master"
+            "bootstrap3-typeahead": "git://github.com/bassjobsen/Bootstrap-3-Typeahead.git#master"
             }
        }
 


### PR DESCRIPTION
Using ssh url may produce  `Failed to execute "git ls-remote --tags --heads git@github.com:bassjobsen/Bootstrap-3-Typeahead.git", exit code of #128 Warning: Permanently added 'github.com,192.30.252.130' (RSA) to the list of known hosts. Permission denied (publickey). fatal: Could not read from remote repository.  Please make sure you have the correct access rights and the repository exists.