### PR TITLE
Avoid twice proccess

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -145,7 +145,7 @@
 
       var worker = $.proxy(function() {
 
-        if($.isFunction(this.source)) this.process(this.source(this.query, $.proxy(this.process, this)));
+        if($.isFunction(this.source)) this.source(this.query, $.proxy(this.process, this));
         else if (this.source) {
           this.process(this.source);
         }


### PR DESCRIPTION
If source is a function, the second param is the "proccess" function. The source function doesn't return anything, so callign "proccess" with items = undefined provoke a error in $.grep (process function).

If someone wasn't using the callback parameter, and the source returns someting (that will be proccess), for legacy, it could be:

```javascript
if($.isFunction(this.source)) {
	var source = this.source(this.query, $.proxy(this.process, this));
	if (source !== undefined) {
		//legacy
		this.process(source);
	}
}
else if (this.source) {
	this.process(this.source);
}
```