### PR TITLE
Fix bug focus (introduced in pull request #193)

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -435,6 +435,7 @@
     click: function (e) {
       e.preventDefault();
       this.select();
+      this.$element.focus();
       this.hide();
     },
 


### PR DESCRIPTION
By removing
```javascript
this.$element.focus();
```

The popup is hiden after move the mouse over an option

```javascript
mouseleave: function (e) {
  this.mousedover = false;
  if (!this.focused && this.shown) this.hide();
}
```