### PR TITLE
Check if data[option] is undefined

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -468,13 +468,13 @@
         , data = $this.data('typeahead')
         , options = typeof option == 'object' && option;
       if (!data) $this.data('typeahead', (data = new Typeahead(this, options)));
-      if (typeof option == 'string') {
+      if (typeof option == 'string' && data[option]) {
         if (arg.length > 1) {
           data[option].apply(data, Array.prototype.slice.call(arg ,1));
         } else {
           data[option]();
         }
-      }
+      } 
     });
   };
 


### PR DESCRIPTION
Value check is missing in the `$.fn.typeahead` constructor, around line 471 :

```
if (typeof option == 'string') {
    if (arg.length > 1) {
       data[option].apply(data, Array.prototype.slice.call(arg ,1));
     } else {
       data[option]();
     }
 }
```

If `data[option]` for some reason is undefined, a nasty _Cannot read property 'apply' of undefined_ is raised. This happens when the typeahead is used along with bootstrap-tagsinput, perhaps elsewhere too. There should be looked into how bootstrap-tagsinput uses the typeahead as well, but the typeahead itself should really make a sanity check on `data[option] `before treating it as valid :

```
if (typeof option == 'string' && data[option]) {
    if (arg.length > 1) {
       data[option].apply(data, Array.prototype.slice.call(arg ,1));
     } else {
       data[option]();
     }
 }
```

See https://github.com/bootstrap-tagsinput/bootstrap-tagsinput/issues/452 and http://stackoverflow.com/q/35379379/1407478