### PR TITLE
Prevent crash when "item.name" is an empty string.

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -310,7 +310,7 @@
     },
 
     displayText: function (item) {
-      return typeof item !== 'undefined' && typeof item.name != 'undefined' && item.name || item;
+      return typeof item !== 'undefined' && typeof item.name != 'undefined' ? item.name : item;
     },
 
     next: function (event) {


### PR DESCRIPTION
Prevent crash when "item" is an object with property "name", but "name" is an empty string.
The previous shorthand would return "item" when "item.name" was an empty string, resulting in an exception.