### PR TITLE
Fixes addItem not showing when item length greater than items limit

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -197,16 +197,16 @@
         this.$element.data('active', null);
       }
 
+      if (this.options.items != 'all') {
+        items = items.slice(0, this.options.items);
+      }
+
       // Add item
       if (this.options.addItem){
         items.push(this.options.addItem);
       }
 
-      if (this.options.items == 'all') {
-        return this.render(items).show();
-      } else {
-        return this.render(items.slice(0, this.options.items)).show();
-      }
+      return this.render(items).show();
     },
 
     matcher: function (item) {


### PR DESCRIPTION
This fixes the issue of the *addItem* not showing up in the dropdownmenu, if the items array has a length greater then specified in the *items* option.

The change pushes the addItem into the resultset after the slice has occurred, preventing it from being excluded from the final items collection.

This issue was mentioned by @schmijos in Issue #201
