### PR TITLE
Handle tabbing into a field with showHintOnFocus

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -444,6 +444,9 @@
           break;
 
         case 9: // tab
+          if (!this.shown || this.showHintOnFocus) return;
+          this.select();
+          break;
         case 13: // enter
           if (!this.shown) return;
           this.select();

--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -68,6 +68,7 @@
     this.afterSelect = this.options.afterSelect;
     this.addItem = false;
     this.value = this.$element.val() || this.$element.text();
+    this.keyPressed = false;
   };
 
   Typeahead.prototype = {
@@ -408,6 +409,7 @@
     },
 
     keydown: function (e) {
+      this.keyPressed = true;
       this.suppressKeyPressRepeat = ~$.inArray(e.keyCode, [40,38,9,13,27]);
       if (!this.shown && e.keyCode == 40) {
         this.lookup();
@@ -444,7 +446,7 @@
           break;
 
         case 9: // tab
-          if (!this.shown || this.showHintOnFocus) return;
+          if (!this.shown || (this.showHintOnFocus && !this.keyPressed)) return;
           this.select();
           break;
         case 13: // enter
@@ -458,12 +460,12 @@
           break;
       }
 
-
     },
 
     focus: function (e) {
       if (!this.focused) {
         this.focused = true;
+        this.keyPressed = false;
         if (this.options.showHintOnFocus && this.skipShowHintOnFocus !== true) {
           if(this.options.showHintOnFocus === "all") {
             this.lookup(""); 
@@ -481,6 +483,7 @@
       if (!this.mousedover && !this.mouseddown && this.shown) {
         this.hide();
         this.focused = false;
+        this.keyPressed = false;
       } else if (this.mouseddown) {
         // This is for IE that blurs the input when user clicks on scroll.
         // We set the focus back on the input and prevent the lookup to occur again


### PR DESCRIPTION
As noted in
https://github.com/bassjobsen/Bootstrap-3-Typeahead/issues/107, when
`showHintOnFocus` is not `false` and a user tabs into an auto-select field,
the `keyUp` from the tab press causes the first item in the list to be
selected.

This is rarely what is wanted, so this commit changes the `keyup`
handler to ignore tabs when the list is shown and `showHintOnFocus` is
set.

Note that this does mean that pressing the tab key when
`showHintOnFocus` is set will never select the highlighted item if any, whereas
when `showHintOnFocus` is false it will.