### PR TITLE
[fix] bloodhound since v0.11 needs two callback methods

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -167,7 +167,12 @@
 
       var worker = $.proxy(function () {
 
-        if ($.isFunction(this.source)) {
+        // Bloodhound (since 0.11) needs three arguments. 
+        // Two of them are callback functions (sync and async) for local and remote data processing
+        // see https://github.com/twitter/typeahead.js/blob/master/src/bloodhound/bloodhound.js#L132
+        if ($.isFunction(this.source) && this.source.length === 3) {
+          this.source(this.query, $.proxy(this.process, this), $.proxy(this.process, this));
+        } else if ($.isFunction(this.source)) {
           this.source(this.query, $.proxy(this.process, this));
         } else if (this.source) {
           this.process(this.source);


### PR DESCRIPTION
The current versions does not work with the latest Bloodhound version 0.11.1.
Bloodhound (since 0.11) needs three arguments. Two of them are callback functions (sync and async) for local and remote data processing. 

see https://github.com/twitter/typeahead.js/blob/master/src/bloodhound/bloodhound.js#L132

This PR will fix #218 and certain other issues I guess.