### PR TITLE
Add options to use href for each items

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -57,6 +57,8 @@
     this.render = this.options.render || this.render;
     this.updater = this.options.updater || this.updater;
     this.displayText = this.options.displayText || this.displayText;
+    this.itemLink = this.options.itemLink || this.itemLink;
+    this.followLinkOnSelect = this.options.followLinkOnSelect || this.followLinkOnSelect;
     this.source = this.options.source;
     this.delay = this.options.delay;
     this.$menu = $(this.options.menu);
@@ -66,6 +68,7 @@
     this.listen();
     this.showHintOnFocus = typeof this.options.showHintOnFocus == 'boolean' || this.options.showHintOnFocus === "all" ? this.options.showHintOnFocus : false;
     this.afterSelect = this.options.afterSelect;
+    this.afterEmptySelect = this.options.afterEmptySelect;
     this.addItem = false;
     this.value = this.$element.val() || this.$element.text();
     this.keyPressed = false;
@@ -76,22 +79,34 @@
     constructor: Typeahead,
 
     select: function () {
-      var val = this.$menu.find('.active').data('value');
-      this.$element.data('active', val);
-      if (this.autoSelect || val) {
-        var newVal = this.updater(val);
-        // Updater can be set to any random functions via "options" parameter in constructor above.
-        // Add null check for cases when updater returns void or undefined.
-        if (!newVal) {
-          newVal = '';
+        var val = this.$menu.find('.active').data('value');
+
+        this.$element.data('active', val);
+        if (this.autoSelect || val) {
+            var newVal = this.updater(val);
+            // Updater can be set to any random functions via "options" parameter in constructor above.
+            // Add null check for cases when updater returns void or undefined.
+            if (!newVal) {
+              newVal = '';
+            }
+            this.$element
+              .val(this.displayText(newVal) || newVal)
+              .text(this.displayText(newVal) || newVal)
+              .change();
+            this.afterSelect(newVal);
+            if(this.followLinkOnSelect && this.itemLink(val)) {
+                document.location = this.itemLink(val);
+                this.afterSelect(newVal);
+            } else if(this.followLinkOnSelect && !this.itemLink(val)) {
+                this.afterEmptySelect(newVal);
+            } else {
+                this.afterSelect(newVal);
+            }
+        } else {
+            this.afterEmptySelect(newVal);
         }
-        this.$element
-          .val(this.displayText(newVal) || newVal)
-          .text(this.displayText(newVal) || newVal)
-          .change();
-        this.afterSelect(newVal);
-      }
-      return this.hide();
+
+        return this.hide();
     },
 
     updater: function (item) {
@@ -311,6 +326,9 @@
         var text = self.displayText(item);
         i = $(that.options.item).data('value', item);
         i.find('a').html(that.highlighter(text, item));
+        if(this.followLinkOnSelect) {
+            i.find('a').attr('href', self.itemLink(item));
+        }
         if (text == self.$element.val()) {
           i.addClass('active');
           self.$element.data('active', item);
@@ -329,6 +347,10 @@
 
     displayText: function (item) {
       return typeof item !== 'undefined' && typeof item.name != 'undefined' ? item.name : item;
+    },
+
+    itemLink: function (item) {
+      return null;
     },
 
     next: function (event) {
@@ -581,7 +603,9 @@
     scrollHeight: 0,
     autoSelect: true,
     afterSelect: $.noop,
+    afterEmptySelect: $.noop,
     addItem: false,
+    followLinkOnSelect: false,
     delay: 0,
     separator: 'category',
     headerHtml: '<li class="dropdown-header"></li>',


### PR DESCRIPTION
Adding 3 options to associate a link (thank to the href property) to each item :
- followLinkOnSelect: follow the item's link when item is selected
- itemLink : callback function that defines the href property (like displayText)
- afterEmptySelect: event triggered when the select method is called with a empty link

I try to implement the behavior of twitter's search autocomplete
