### PR TITLE
Add setDefault function to set default select

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -78,27 +78,6 @@
 
     setDefault: function (val) {
       // var val = this.$menu.find('.active').data('value');
-      console.log(val)
-      this.$element.data('active', val);
-      if (this.autoSelect || val) {
-        var newVal = this.updater(val);
-        // Updater can be set to any random functions via "options" parameter in constructor above.
-        // Add null check for cases when updater returns void or undefined.
-        if (!newVal) {
-          newVal = '';
-        }
-        this.$element
-          .val(this.displayText(newVal) || newVal)
-          .text(this.displayText(newVal) || newVal)
-          .change();
-        this.afterSelect(newVal);
-      }
-      return this.hide();
-    },
-
-    select: function () {
-      var val = this.$menu.find('.active').data('value');
-      console.log(val)
       this.$element.data('active', val);
       if (this.autoSelect || val) {
         var newVal = this.updater(val);

--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -75,6 +75,47 @@
 
     constructor: Typeahead,
 
+
+    setDefault: function (val) {
+      // var val = this.$menu.find('.active').data('value');
+      console.log(val)
+      this.$element.data('active', val);
+      if (this.autoSelect || val) {
+        var newVal = this.updater(val);
+        // Updater can be set to any random functions via "options" parameter in constructor above.
+        // Add null check for cases when updater returns void or undefined.
+        if (!newVal) {
+          newVal = '';
+        }
+        this.$element
+          .val(this.displayText(newVal) || newVal)
+          .text(this.displayText(newVal) || newVal)
+          .change();
+        this.afterSelect(newVal);
+      }
+      return this.hide();
+    },
+
+    select: function () {
+      var val = this.$menu.find('.active').data('value');
+      console.log(val)
+      this.$element.data('active', val);
+      if (this.autoSelect || val) {
+        var newVal = this.updater(val);
+        // Updater can be set to any random functions via "options" parameter in constructor above.
+        // Add null check for cases when updater returns void or undefined.
+        if (!newVal) {
+          newVal = '';
+        }
+        this.$element
+          .val(this.displayText(newVal) || newVal)
+          .text(this.displayText(newVal) || newVal)
+          .change();
+        this.afterSelect(newVal);
+      }
+      return this.hide();
+    },
+
     select: function () {
       var val = this.$menu.find('.active').data('value');
       this.$element.data('active', val);


### PR DESCRIPTION
Add setDefault function to let people can set default select of typeahead.


`$input.typeahead('select2', {id:1,name:"test"})`
`alert($input.typeahead("getActive").id`