### PR TITLE
#285 Improve Bootstrap 4 support

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -346,7 +346,7 @@
 
         var text = self.displayText(item);
         i = $(that.options.item).data('value', item);
-        i.find('a').html(that.highlighter(text, item));
+        i.find(that.options.itemContentSelector).addBack(that.options.itemContentSelector).html(that.highlighter(text, item));
         if(this.followLinkOnSelect) {
             i.find('a').attr('href', self.itemLink(item));
         }
@@ -641,6 +641,7 @@
     items: 8,
     menu: '<ul class="typeahead dropdown-menu" role="listbox"></ul>',
     item: '<li><a class="dropdown-item" href="#" role="option"></a></li>',
+    itemContentSelector:'a',
     minLength: 1,
     scrollHeight: 0,
     autoSelect: true,


### PR DESCRIPTION
In bootstrap 4 we no longer use an additional div around the dropdown-items.

For this I needed 2 changes.
1. Add the 'addBack' functionality so I can select the item element it self
2. I added a itemContentSelector. With this you can change the selector for getting the element in which you want to add the content. For backwards compatibility reasons I have set this to 'a' as default.

To get a Bootstrap 4 example I had to set the following:
{
    menu: "<div class=\"typeahead dropdown-menu\" role=\"listbox\"></div>",
    item: "<button class=\"dropdown-item\" type=\"button\" role=\"option\"></button>",
    headerHtml: "<h6 class=\"dropdown-header\"></h6>",
    headerDivider: "<div class=\"dropdown-divider\"></div>",
    itemContentSelector: '.dropdown-item'
}