### PR TITLE
fix file not found issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Bass Jobsen",
   "scripts": {
     "test": "grunt test",
-    "uglify" : "uglifyjs ./bootstrap3-typeahead.js --output ./bootstrap3-typeahead.min.js --warn --compress drop_console=true"
+    "uglify": "uglifyjs ./bootstrap3-typeahead.js --output ./bootstrap3-typeahead.min.js --warn --compress drop_console=true"
   },
   "repository": {
     "type": "git",
@@ -33,9 +33,6 @@
   },
   "engines": {
     "node": "~0.10.1"
-  },
-  "bin": {
-    "grunt": "./node_modules/grunt/lib/grunt.js"
   },
   "dependencies": {
     "uglify-js": "^3.3.7"


### PR DESCRIPTION
Hi!
When I do `npm i https://github.com/bassjobsen/Bootstrap-3-Typeahead.git` I got error:
```
npm ERR! path /Users/user/projects/project/node_modules/bootstrap-3-typeahead/node_modules/grunt/lib/grunt.js
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall chmod
npm ERR! enoent ENOENT: no such file or directory, chmod '/Users/user/projects/project/node_modules/bootstrap-3-typeahead/node_modules/grunt/lib/grunt.js'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/user/.npm/_logs/2018-01-21T13_40_31_554Z-debug.log
```

So, this PR is a fix for that.
