### PR TITLE
Relax versioning in engines.node

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "load-grunt-tasks": "~0.6.0"
   },
   "engines": {
-    "node": "~0.10.1"
+    "node": ">=0.10.1"
   },
   "dependencies": {
     "uglify-js": "^3.3.7"


### PR DESCRIPTION
This package will fail to install in projects using the `engine-strict` npm config, unless they are using node 0.10.x:

npm install
...
npm ERR! notsup Unsupported engine for bootstrap-3-typeahead@4.0.2: wanted: {"node":"~0.10.1"}

This commit fixes this issue.