### PR TITLE
updater should not be triggered on move

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -415,10 +415,10 @@
 
             next.addClass('active');
             // added for screen reader
-            var newVal = this.updater(next.data('value'));
-            if (this.changeInputOnMove) {
-                this.$element.val(this.displayText(newVal) || newVal);
-            }
+            //var newVal = this.updater(next.data('value'));
+            //if (this.changeInputOnMove) {
+            //    this.$element.val(this.displayText(newVal) || newVal);
+            //}
         },
 
         prev: function (event) {
@@ -435,10 +435,10 @@
 
             prev.addClass('active');
             // added for screen reader
-            var newVal = this.updater(prev.data('value'));
-            if (this.changeInputOnMove) {
-                this.$element.val(this.displayText(newVal) || newVal);
-            }
+            //var newVal = this.updater(prev.data('value'));
+            //if (this.changeInputOnMove) {
+            //    this.$element.val(this.displayText(newVal) || newVal);
+            //}
         },
 
         listen: function () {


### PR DESCRIPTION
I know most probably you will not accept it but in original typeahead `updater` was triggered when the value was selected. To trigger it every time you change active element in the list without enter or tab is wrong.

For example, I use it like this

```js
var input = $($.parseHTML($self.options.templates.input))
.attr({ placeholder: $self.options.placeholder })
.typeahead({
	source: function(query, process) {
		var suggestions = $.merge([], $self.options.suggestions);

		if ($self.options.suggestion_url) {
			$.ajax({
				dataType: "json",
				async: false,
				url: $self.options.suggestion_url,
				data: { q: query, limit: $self.options.suggestion_limit }
			}).done(function(json) {
				if (typeof json == "object") {
					suggestions = $.merge(suggestions, json);
					suggestions = $self._prepare(suggestions);
					suggestions = $self.options.onLoadSuggestions(suggestions);
					process(suggestions);
				}
			});
		} else {
			suggestions = $self._prepare(suggestions);
			suggestions = $self.options.onLoadSuggestions(suggestions);
			process(suggestions);
		}
	},
	updater: function(item) {
		console.log(item);
		$self._addTag(pills_list, input, item);
	}
});
```

whee `$self._addTag(pills_list, input, item);` add a new pill to the list, It is my shttps://github.com/Serhioromano/bootstrap-tags library. It is not super popular but has few stars there. If you do not accept I'll comment it locally and pack my library as a bundle with hacked version.